### PR TITLE
remove useless resolver setting from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ In order to add the sbt-gcs plugin to your build, add the following to `project/
 
 
 ```project/plugins.sbt
-resolvers += Resolver.bintrayIvyRepo("saint1991", "sbt-plugins")
 addSbtPlugin("com.github.saint1991" % "sbt-gcs" % "0.2.0")
 ```
 


### PR DESCRIPTION
Remove resolver settings from README. That became needless because linked to sbt community plugin repository.