### PR TITLE
Fix update task

### DIFF
--- a/src/main/scala/com/github/saint1991/sbt/gcs/GcsTasks.scala
+++ b/src/main/scala/com/github/saint1991/sbt/gcs/GcsTasks.scala
@@ -101,14 +101,12 @@ object GcsTasks {
       .build()
 
     Task {
-      using(new BufferedInputStream(new FileInputStream(src))) { in =>
-        using(config.storage.writer(blobInfo).asOutputStream) { out =>
-          Await.ready(copyStream(config)(in, out).foreach(_ => ()), config.timeout)
-        }
-      }
+      val storage = getStorage(config.credential)
+      storage.create(blobInfo, Files.readAllBytes(src.toPath))
       (src, dest)
     }.memoizeOnSuccess
   }
+
 
   /**
     * Download *src* object from Google Cloud Storage as the *dest* file.


### PR DESCRIPTION
Current `upload` task is stream-based.
Therefore, it caused us some issues when network was unstable.

The suggested solution is using the gcs library without streaming.
The file is written using the gcs `storage` object.